### PR TITLE
Add initial OpenLab charter

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,86 @@
+### OpenLab Testing Charter v1.0
+
+Effective 13 May 2019
+
+#### 1) Mission and Scope of the OpenLab project
+
+- a) The purpose of the OpenLab project is to promote the testing and
+     verification of Open Source projects.
+
+- b) OpenLab will stay a vendor and open source foundation neutral place where
+     testing can be performed on any Open Source project to help promote interoperability and prove out valid configurations.
+
+  - i) All tested software must be under [an approved Open Source
+       license](https://opensource.org/licenses/alphabetical).
+
+  - ii) Productized versions of Open Source projects are not appropriate for
+        testing with OpenLab resources.
+
+  - iii) Testing of upstream Open Source projects should be an indication that
+         products based on that upstream code is compatible. Any incompatibility
+         issues would be the responsibility and the purview of that vendor.
+
+- c) One of the goals of OpenLab is to test the new "LAMP stack" for various
+     use cases. That is, we want to assemble and validate tested combinations
+     of different Open Source projects that may be used together to build larger
+     solutions that can address the actual needs of the end user.
+
+- d) OpenLab provides a place for different Open Source projects to work
+     together, assistance in identifying testing and operability concerns, and
+     a place for supporting providers to contribute cloud and physical device
+     access to promote the overall Open Source ecosystem.
+
+#### 2) Membership
+
+- a) There are three levels of "membership" in the OpenLab community:
+
+  - i) **General Members** - anyone who participates in OpenLab activities (test
+       development, operations, test platform contribution, or promoting
+       OpenLab efforts in the greater community) are considered general members
+       of OpenLab.
+
+  - ii) **Operations Managers** - those who have participated in the operations
+        of the OpenLab CI system and ensured operability of OpenLab
+        infrastructure are considered Operations Managers. This group has access
+        to the cloud account information and critical systems that make up
+        OpenLab and are therefore limited to those that have gained community
+        trust and have been nominated into the role by existing Operations
+        Managers.
+
+  - iii) **Program Managers** - the OpenLab Program Managers are responsible
+         for enforcing the OpenLab mission for all tested solutions and are
+         promoters of the OpenLab effort in outreach to other Open Source
+         communities and supporting companies.
+
+#### 3) Technical Steering Committee
+
+- a) The Technical Steering Committee (TSC) is comprised of OpenLab Program
+     Managers.
+
+- b) The TSC is responsible for promoting the OpenLab effort across different
+     Open Source communities to help grow involvement in Open Source testing
+     and helping onboard new projects to add or expand different technology
+     stacks.
+    
+- c) As part of the TSC, Program Managers will approve or deny new requests for
+     testing as appropriate to ensure all efforts align with the OpenLab
+     mission.
+
+#### 4) Operations Infrastructure
+
+- a) Operations Managers will help set up new projects with test advice and
+     configuration support.
+    
+- b) Operations Managers will assist new projects with triaging test failures
+     and identifying root cause of failures until the projects are able to
+     perform these actions on their own.
+
+- c) Infrastructure providers - those that provide cloud VM, container, or
+     physical host access to OpenLab for testing - are key to the operation of
+     OpenLab.
+    
+  - i) Providers are donating these resources because they want to support
+       the Open Source ecosystem and they believe in the OpenLab mission.
+
+  - ii) OpenLab Operations Managers and Program Managers will make sure these
+        donated resources are used appropriately.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
-# OpenLab task tracking
+# OpenLab Governance
 This repository is used for governance and general community documentation for
 the OpenLab community.
 
 If this is first time you have come to OpenLab, please start with OpenLab
 [Getting Started](https://docs.openlabtesting.org/publications/).
 
-# More information
+## OpenLab Charter
+
+Information on the mission and goals for OpenLab can be found in the
+[OpenLab Charter](CHARTER.md).
+
+### More information
 OpenLab Website:
 
 https://openlabtesting.org/


### PR DESCRIPTION
This is an initial version of a charter for OpenLab. It is not expected to be exhausted or a final version by any stretch. The hope is this will give us a starting point to further refine to make sure we are clearly declaring how OpenLab works and what is expected from the project.